### PR TITLE
Fixing useless TypeFilterLevel setting when using lease

### DIFF
--- a/ExploitRemotingService/Program.cs
+++ b/ExploitRemotingService/Program.cs
@@ -77,8 +77,13 @@ namespace ExploitRemotingService
                 BinaryClientFormatterSinkProvider clientProvider = new BinaryClientFormatterSinkProvider(props, null);
                 IDictionary dict = new Hashtable();
 
-                serverProvider.TypeFilterLevel = _typeFilterLevel;
-
+                if (!_uselease)
+                    serverProvider.TypeFilterLevel = _typeFilterLevel;
+                else
+                    //When using the lease method the TypeFilterLevel has to be set to full,
+                    //otherwise the Method call to GetHashCode with the MBR will fail due to
+                    //ObjectReader::CheckSecurity.
+                    serverProvider.TypeFilterLevel = TypeFilterLevel.Full;
                 IChannel channel;
 
                 switch (_uri.Scheme)


### PR DESCRIPTION
This commit forces TypeFilterLevel.Full when using the lease method, otherwise the exploit will fail due to the security check in ObjectReader when the target tries to call GetHashCode with a MarshalByRefObject.