### PR TITLE
Add support for fixing channel URIs

### DIFF
--- a/ExploitRemotingService/ChannelUriFixingClientChannelSinkProvider.cs
+++ b/ExploitRemotingService/ChannelUriFixingClientChannelSinkProvider.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Runtime.Remoting.Channels;
+
+namespace ExploitRemotingService
+{
+    internal class ChannelUriFixingClientChannelSinkProvider : IClientChannelSinkProvider
+    {
+        private readonly string publicHost;
+
+        public IClientChannelSinkProvider Next { get; set; }
+
+        public ChannelUriFixingClientChannelSinkProvider(string publicHost)
+        {
+            this.publicHost = publicHost;
+        }
+
+        public IClientChannelSink CreateSink(IChannelSender channel, string url, object remoteChannelData)
+        {
+            IClientChannelSink clientChannelSink = null;
+            if (this.Next != null)
+            {
+                url = new UriBuilder(url)
+                {
+                    Host = this.publicHost,
+                }.ToString();
+                clientChannelSink = this.Next.CreateSink(channel, url, remoteChannelData);
+            }
+            return clientChannelSink;
+        }
+    }
+}

--- a/ExploitRemotingService/ChannelUriFixingServerChannelSinkProvider.cs
+++ b/ExploitRemotingService/ChannelUriFixingServerChannelSinkProvider.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using System.Runtime.Remoting.Channels;
+
+namespace ExploitRemotingService
+{
+    internal class ChannelUriFixingServerChannelSinkProvider : IServerChannelSinkProvider
+    {
+        private readonly string publicHost;
+        private readonly int publicPort;
+
+        public IServerChannelSinkProvider Next { get; set; }
+
+        public ChannelUriFixingServerChannelSinkProvider(string publicHost, int publicPort)
+        {
+            this.publicHost = publicHost;
+            this.publicPort = publicPort;
+        }
+
+        public IServerChannelSink CreateSink(IChannelReceiver channel)
+        {
+            IServerChannelSink serverChannelSink = null;
+            if (this.Next != null)
+            {
+                serverChannelSink = this.Next.CreateSink(channel);
+            }
+            return serverChannelSink;
+        }
+
+        public void GetChannelData(IChannelDataStore channelData)
+        {
+            if (this.Next != null)
+            {
+                this.Next.GetChannelData(channelData);
+            }
+            for (int i = 0; i < channelData.ChannelUris.Length; i++)
+            {
+                var uri = new Uri(channelData.ChannelUris[i]);
+                channelData.ChannelUris[i] = new UriBuilder(uri)
+                {
+                    Host = this.publicHost ?? uri.Host,
+                    Port = this.publicPort,
+                }.ToString();
+            }
+        }
+    }
+}

--- a/ExploitRemotingService/Program.cs
+++ b/ExploitRemotingService/Program.cs
@@ -43,6 +43,8 @@ namespace ExploitRemotingService
     {
         private static Uri _uri;
         private static int _port;
+        private static string _publicHost;
+        private static int _publicPort;
         private static string _cmd;
         private static List<string> _cmdargs;
         private static string _username;
@@ -73,8 +75,14 @@ namespace ExploitRemotingService
                 props["includeVersions"] = false;
                 props["tokenimpersonationlevel"] = _tokenImpersonationLevel.ToString();
 
-                BinaryServerFormatterSinkProvider serverProvider = new BinaryServerFormatterSinkProvider(props, null);
-                BinaryClientFormatterSinkProvider clientProvider = new BinaryClientFormatterSinkProvider(props, null);
+                BinaryServerFormatterSinkProvider serverProvider = new BinaryServerFormatterSinkProvider(props, null)
+                {
+                    Next = new ChannelUriFixingServerChannelSinkProvider(_publicHost, _publicPort),
+                };
+                BinaryClientFormatterSinkProvider clientProvider = new BinaryClientFormatterSinkProvider(props, null)
+                {
+                    Next = new ChannelUriFixingClientChannelSinkProvider(_uri.Host),
+                };
                 IDictionary dict = new Hashtable();
 
                 if (!_uselease)
@@ -166,6 +174,8 @@ namespace ExploitRemotingService
             bool debug = false;
             bool showhelp = false;
             _port = 11111;
+            _publicHost = null;
+            _publicPort = _port;
             _ipcname = "remotingexploit";
             _remotename = typeof(IRemoteClass).Assembly.GetName().Name;
             _ver = 0;
@@ -180,6 +190,8 @@ namespace ExploitRemotingService
                         v => Enum.TryParse(v, true, out _tokenImpersonationLevel)
                     },
                     { "p|port=", "Specify the local TCP port to listen on", v => _port = int.Parse(v) },
+                    { "publichost=", "Specify the public host for reverse connections", v => _publicHost = v },
+                    { "publicport=", "Specify the public TCP port for reverse connections", v => _publicPort = int.Parse(v) },
                     { "i|ipc=", "Specify listening pipe name for IPC channel", v => _ipcname = v },
                     { "user=", "Specify username for secure mode", v => {
                         _username = v;


### PR DESCRIPTION
Add support for fixing the incoming and outgoing channel URIs:

- `ChannelUriFixingClientChannelSinkProvider` handles incoming channel URIs originating from the targeted .NET Remoting service, which may contain internal, non-reachable addresses. Here, the host of the targeted URI is used instead.

- `ChannelUriFixingServerChannelSinkProvider` handles outgoing channel URIs used by *ExploitRemotingService*. The newly introduced options `--publicHost` and `--publicPort` can be used to point the .NET Remoting service to a specific address instead of the one, possibly internal address known to *ExploitRemotingService*.