### PR TITLE
Add missing source code references

### DIFF
--- a/ExploitRemotingService/ExploitRemotingService.csproj
+++ b/ExploitRemotingService/ExploitRemotingService.csproj
@@ -91,6 +91,8 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="ChannelUriFixingClientChannelSinkProvider.cs" />
+    <Compile Include="ChannelUriFixingServerChannelSinkProvider.cs" />
     <Compile Include="CustomChannel.cs" />
     <Compile Include="DataSetMarshal.cs" />
     <Compile Include="MethodCallWrapper.cs" />


### PR DESCRIPTION
Add missing references to `ChannelUriFixingClientChannelSinkProvider.cs` and `ChannelUriFixingServerChannelSinkProvider.cs`

Resolves #11