### PR TITLE
Fixes OS version command according to documentation

### DIFF
--- a/ExploitRemotingService/Program.cs
+++ b/ExploitRemotingService/Program.cs
@@ -643,7 +643,7 @@ raw base64_object|file        : Send a raw serialized object to the service.
                 case "user":
                     Console.WriteLine("User: {0}", c.GetUsername());
                     break;
-                case "osver":
+                case "ver":
                     Console.WriteLine("OS: {0}", c.GetOSVersion());
                     break;
                 default:


### PR DESCRIPTION
According to the documentation the command to retrieve the OS version information is `ver`. In `ExploitRemotingService`, the internally interpreted command is `osver`. This pull request fixes the command supplied to `ExploitRemotingService` from `osver` to `ver` to align with the documentation.